### PR TITLE
Preserve app data if neither ce nor de have xattr user.default

### DIFF
--- a/cmds/installd/commands.cpp
+++ b/cmds/installd/commands.cpp
@@ -238,11 +238,15 @@ int migrate_app_data(const char *uuid, const char *pkgname, userid_t userid, int
     auto ce_path = create_data_user_ce_package_path(uuid, userid, pkgname);
     auto de_path = create_data_user_de_package_path(uuid, userid, pkgname);
 
-    // If neither directory is marked as default, assume CE is default
+    // If neither directory is marked as default, use DE if requested by
+    // the app (and it exists), otherwise assume CE.
     if (getxattr(ce_path.c_str(), kXattrDefault, nullptr, 0) == -1
             && getxattr(de_path.c_str(), kXattrDefault, nullptr, 0) == -1) {
-        if (setxattr(ce_path.c_str(), kXattrDefault, nullptr, 0, 0) != 0) {
-            PLOG(ERROR) << "Failed to mark default storage " << ce_path;
+        struct stat s;
+        const char *data_path = (flags & FLAG_STORAGE_DE) && !stat(de_path.c_str(), &s)
+                ? de_path.c_str() : ce_path.c_str();
+        if (setxattr(data_path, kXattrDefault, nullptr, 0, 0) != 0) {
+            PLOG(ERROR) << "Failed to mark default storage " << data_path;
             return -1;
         }
     }


### PR DESCRIPTION
For a given app, if xattr user.default is missing from both ce and de data
dirs, installd currently defaults to using ce.  However, if a system
app sets defaultToDeviceProtectedStorage="true" in it's manifest,
data is actually stored in de and so the effect is wipe for such
apps in the case where xattr user.default attributes are missing
(such as a tar backup/restore).

In the case where user.default is missing, if the app wants de
and the de dir exists then use it, otherwise, default to ce
as before.

Change-Id: I8d5583b7d156809b2aecc676db35e6bf7cad3e0c